### PR TITLE
Add missing "Blog" section in table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Markdown format:
 - [Automatic Speech Recognition (ASR)](#asr)
 - [Talks](#talks)
 - [Thesis](#thesis)
+- [Blog](#blog)
 
 ## Computer Vision
 ### Survey


### PR DESCRIPTION
The table of contents section in the beginning of the README file doesn't contain "Blog" section. I have added an entry to fix that.

![image](https://user-images.githubusercontent.com/8587189/75611679-bfae5b00-5b44-11ea-817f-b19f1c7359f5.png)
