### PR TITLE
Add paper summaries of SimCLR and PIRL

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,8 @@ FAIR Self-Supervision Benchmark [[repo]](https://github.com/facebookresearch/fai
 ## Blog
 - Self-Supervised Representation Learning. Lilian Weng. [[link]](https://lilianweng.github.io/lil-log/2019/11/10/self-supervised-learning.html).
 - The Illustrated Self-Supervised Learning. Amit Chaudhary. [[link]](https://amitness.com/2020/02/illustrated-self-supervised-learning/)
+- The Illustrated SimCLR Framework. Amit Chaudhary. [[link]](https://amitness.com/2020/03/illustrated-simclr/)
+- The Illustrated PIRL: Pretext-Invariant Representation Learning. Amit Chaudhary. [[link]](https://amitness.com/2020/03/illustrated-pirl/)
 
 ## License
 To the extent possible under law, [Zhongzheng Ren](https://jason718.github.io/) has waived all copyright and related or neighboring rights to this work.


### PR DESCRIPTION
Hi @jason718,

I have added links to paper summaries of **SimCLR** and **PIRL** under the blog section. Please review it and merge the PR.
![](https://amitness.com/images/simclr-general-architecture.png)
![](https://amitness.com/images/pirl-general-architecture.png)